### PR TITLE
Remove emoji from dependency alert

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -448,7 +448,7 @@ webSocketServer.on('connection', connection => {
         }
         if (!dependencyInstallationDone) {
             contents.push(
-                'ℹ️ _Dependency installation is still in progress. The information shown might be missing type information._'
+                '_Dependency installation is still in progress. The information shown might be missing type information._'
             )
         }
         return { ...hover, contents }


### PR DESCRIPTION
Removed emoji from dependency alert because it doesn't follow our style guide for alerts, and isn't a proper way to inform of an alert.