### PR TITLE
docs: update for new new extension listing guidelines/fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "lang-typescript",
-  "title": "Code intelligence for TypeScript",
-  "description": "Provides code intelligence for TypeScript",
+  "description": "TypeScript code intelligence",
   "private": true,
   "publisher": "sourcegraph",
   "engines": {
@@ -11,6 +10,8 @@
     "type": "git",
     "url": "https://github.com/sourcegraph/lang-typescript"
   },
+  "categories": ["Programming languages"],
+  "tags": ["typescript", "javascript", "react", "jsx", "cross-repository", "language-server"],
   "activationEvents": [
     "onLanguage:typescript",
     "onLanguage:javascript"


### PR DESCRIPTION
Updates to reflect the changes to extension listings on the extension registry in https://github.com/sourcegraph/sourcegraph/pull/1612:

- Extensions can have tags and categories.

Also:

- Extensions no longer have titles. The extension ID, `sourcegraph/lang-typescript`, and the extension description are the only things shown now. (As of https://github.com/sourcegraph/sourcegraph/pull/1613.)
- The extension description can/should be shorter now that it's shown on 1 line and there is no title.

