### PR TITLE
Respect sourcegraph.url

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -58,6 +58,7 @@ import {
     rewriteUris,
     toServerTextDocumentUri,
     toSourcegraphTextDocumentUri,
+    serverRootUri,
 } from './uris'
 import {
     abortPrevious,
@@ -258,7 +259,7 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                     // until workspace/configuration is allowed during initialize
                     configuration: {
                         // The server needs to use the API to resolve repositories
-                        'sourcegraph.url': sourcegraph.internal.sourcegraphURL.toString(),
+                        'sourcegraph.url': serverRootUri(),
                         ...fromPairs(
                             Object.entries(sourcegraph.configuration.get().value).filter(([key]) =>
                                 key.startsWith('typescript.')
@@ -513,7 +514,7 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                         span.setTag('uri', redact(definition.uri))
                         span.setTag('line', definition.range.start.line)
 
-                        const instanceUrl = new URL(sourcegraph.internal.sourcegraphURL.toString())
+                        const instanceUrl = new URL(serverRootUri())
                         const sgInstance: SourcegraphInstance = {
                             accessToken,
                             instanceUrl,

--- a/extension/src/uris.ts
+++ b/extension/src/uris.ts
@@ -1,11 +1,25 @@
 import * as sourcegraph from 'sourcegraph'
+import { Configuration } from './config'
+
+/**
+ * The root URI for the server, e.g. `https://sourcegraph.com`. This can be
+ * overridden by setting `sourcegraph.url`, which is useful for Docker
+ * deployments that must access the Sourcegraph instance on
+ * `http://host.docker.internal:7080` instead of `http://localhost:7080`.
+ */
+export function serverRootUri() {
+    return (
+        sourcegraph.configuration.get<Configuration>().get('sourcegraph.url') ||
+        sourcegraph.internal.sourcegraphURL.toString()
+    )
+}
 
 /**
  * @param textDocumentUri The Sourcegraph text document URI, e.g. `git://github.com/sourcegraph/extensions-client-common?80389224bd48e1e696d5fa11b3ec6fba341c695b#src/schema/graphqlschema.ts`
  * @returns The root URI for the server, e.g. `https://accesstoken@sourcegraph.com/github.com/sourcegraph/extensions-client-common@80389224bd48e1e696d5fa11b3ec6fba341c695b/-/raw/`. Always has a trailing slash.
  */
 export function resolveServerRootUri(textDocumentUri: URL): URL {
-    const rootUri = new URL(sourcegraph.internal.sourcegraphURL.toString())
+    const rootUri = new URL(serverRootUri())
     // rootUri.username = accessToken
     rootUri.pathname =
         [textDocumentUri.host + textDocumentUri.pathname, textDocumentUri.search.substr(1)].filter(Boolean).join('@') +


### PR DESCRIPTION
This lets site admins override the `sourcegraph.url` so that if a language server is running in Docker containers, it can hit the raw API.